### PR TITLE
Revert "msm8916-common: Default OMX service to non-Treble"

### DIFF
--- a/product/media.mk
+++ b/product/media.mk
@@ -6,8 +6,7 @@ PRODUCT_COPY_FILES += \
 
 # Properties
 PRODUCT_PROPERTY_OVERRIDES += \
-    media.aac_51_output_enabled=true \
-    persist.media.treble_omx=false
+    media.aac_51_output_enabled=true
 
 # WiFi Display
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
-A6000 is the first msm8916 to use treble OMX
This reverts commit 4ef0b4b04895fab24e9939e9baa4c9bc420339df.